### PR TITLE
Automatic install scripts for #11

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MANAGE_SCRIPT_URL="test"
+MANAGE_SCRIPT_URL="https://raw.githubusercontent.com/dwyl/smart-home-security-system/install/manage.py"
 
 check_for_python() {
   if ! command -v python3 >/dev/null

--- a/go.sh
+++ b/go.sh
@@ -16,7 +16,7 @@ check_for_python() {
 install() {
   check_for_python
   echo "Downloading install manager..."
-  wget -O manage.py $MANAGE_SCRIPT_URL
+  wget -q -O manage.py $MANAGE_SCRIPT_URL
   chmod +x manage.py
   echo "Running installer..."
   python3 manage.py install

--- a/go.sh
+++ b/go.sh
@@ -16,7 +16,7 @@ check_for_python() {
 install() {
   check_for_python
   echo "Downloading install manager..."
-  wget -q -O manage.py $MANAGE_SCRIPT_URL
+  curl -sL $MANAGE_SCRIPT_URL -o manage.py
   chmod +x manage.py
   echo "Running installer..."
   python3 manage.py install

--- a/go.sh
+++ b/go.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+MANAGE_SCRIPT_URL="test"
+
+check_for_python() {
+  if ! command -v python3 >/dev/null
+  then
+    echo "Can't find a Python 3 install, which is needed for the setup script."
+    exit 1
+  else
+    echo "Python3 found, continuing..."
+  fi
+
+}
+
+install() {
+  check_for_python
+  echo "Downloading install manager..."
+  # wget -O manage.py MANAGE_SCRIPT_URL
+  echo "Running installer..."
+  python3 manage.py install
+}
+
+install

--- a/go.sh
+++ b/go.sh
@@ -16,7 +16,7 @@ check_for_python() {
 install() {
   check_for_python
   echo "Downloading install manager..."
-  # wget -O manage.py MANAGE_SCRIPT_URL
+  wget -O manage.py $MANAGE_SCRIPT_URL
   echo "Running installer..."
   python3 manage.py install
 }

--- a/go.sh
+++ b/go.sh
@@ -17,6 +17,7 @@ install() {
   check_for_python
   echo "Downloading install manager..."
   wget -O manage.py $MANAGE_SCRIPT_URL
+  chmod +x manage.py
   echo "Running installer..."
   python3 manage.py install
 }

--- a/manage.py
+++ b/manage.py
@@ -59,12 +59,15 @@ def run(*args):
 
 def write_env(key):
   lines = []
-  with open(".env", "r+") as f:
-    keys = filter(
-      lambda x: not "AUTH_API_KEY=" in x, 
-      f.readlines()
-    )
-    lines = [x for x in keys]
+  try:
+    with open(".env", "r+") as f:
+      keys = filter(
+        lambda x: not "AUTH_API_KEY=" in x, 
+        f.readlines()
+      )
+      lines = [x for x in keys]
+  except FileNotFoundError:
+    pass
   
   lines.append("AUTH_API_KEY=" + key + "\n")
   

--- a/manage.py
+++ b/manage.py
@@ -58,9 +58,18 @@ def run(*args):
   return subprocess.run(args, capture_output=not VERBOSE)
 
 def write_env(key):
+  lines = []
+  with open(".env", "r+") as f:
+    keys = filter(
+      lambda x: not "AUTH_API_KEY=" in x, 
+      f.readlines()
+    )
+    lines = [x for x in keys]
+  
+  lines.append("AUTH_API_KEY=" + key + "\n")
+  
   with open(".env", "w") as f:
-    contents = "AUTH_API_KEY=" + key + "\n"
-    f.write(contents)
+    f.writelines(lines)
 
 # Dowload required files from github.
 def download():

--- a/manage.py
+++ b/manage.py
@@ -156,6 +156,12 @@ def check_deps():
   else:
     out("ERROR\n")
 
+  out("Checking for node.js...")
+  if check_software("node --version"):
+    out("OK\n")
+    deps["node"] = True
+  else:
+    out("ERROR")
 
   return deps
 
@@ -163,12 +169,23 @@ def install_deps(brew, missing):
   if not brew:
     must_install_brew()
 
-  
-  out("Installing Elixir...\n")
-  run("brew install elixir")
+  if input("Do you want to install missing dependencies using brew? (y/N)")[0] == "y":
+    out("Attempting to install...\n")
+  else:
+    out("\nPlease ensure dependenices are installed or there could be errors!\n")
+    return # Implicit return seems nicer here...
 
-  out("Installing PostgreSQL...\n")
-  run("brew install postgres")
+  if missing["elixir"]:
+    out("Installing Elixir...\n")
+    run("brew install elixir")
+
+  if missing["psql"]:
+    out("Installing PostgreSQL...\n")
+    run("brew install postgres")
+
+  if missing["node"]:
+    out("Installing node...\n")
+    run("brew install node")
 
 def install_nerves_dependencies():
   if input("Do you want to install build dependencies for nerves? (fwup squashfs coreutils xz pkg-config)? (y/N)")[0] == "y":

--- a/manage.py
+++ b/manage.py
@@ -15,6 +15,7 @@ VERBOSE=False
 HUB_SERVER_REPO="https://github.com/dwyl/smart-home-auth-server.git"
 FIRMWARE_REPO="https://github.com/dwyl/smart-home-firmware.git"
 
+# Declare the start message here so we don't clog up the rest of the code
 START_MESSAGE="""
 Smart home is now setup for development.
 
@@ -48,6 +49,7 @@ def cd(newdir):
 def out(line):
   print(line, end="", flush=True)
 
+# Run a command, and display the result based on wether VERBOSE is set or not
 def run(*args):
   return subprocess.run(args, capture_output=not VERBOSE)
 
@@ -61,6 +63,7 @@ def download():
   process = run("git", "clone", FIRMWARE_REPO)
   out("OK\n")
 
+# Prompt user for an auth API key so we can finish setup
 def get_api_key():
   print("AUTH_API_KEY not set!\n")
   print("No Auth API key set, found out how at:")
@@ -69,6 +72,7 @@ def get_api_key():
   print("Please enter your API key once your done to continue setup")
   os.environ["AUTH_API_KEY"] = input(">")
 
+# Check if we have an auth API key set before continuing
 def check_for_api_key():
   if os.environ.get("AUTH_API_KEY", None):
     # API key set
@@ -76,6 +80,7 @@ def check_for_api_key():
   else:
     get_api_key()
 
+# Get and display a local API development token for the user
 def gen_token():
   with cd("./smart-home-auth-server"):
     proc = subprocess.run(["mix", "smart_home.gen_token"], capture_output=True)
@@ -83,6 +88,7 @@ def gen_token():
     print(proc.stdout.decode(sys.stdout.encoding))
     print("\nSet this as the authorization header in your favourite API development tool.")
 
+# Setup deps etc. for firmware
 def setup():
   # Setup firmware
   with cd("./smart-home-firmware"):
@@ -112,7 +118,7 @@ def clean():
   run("rm", "-rf", "./smart-home-firmware")
   out("OK\n")
 
-
+# Declare our command parsers and run the intended function
 def main():
   parser = argparse.ArgumentParser(description="Manage Dwyl smart home install")
   parser.add_argument("-v", "--verbose", help="Enable verbose output", action="store_true")
@@ -140,6 +146,6 @@ def main():
   if args.func:
     args.func()
 
-
+# Don't run main if we're called from another script.
 if __name__ == "__main__":
   main()

--- a/manage.py
+++ b/manage.py
@@ -5,6 +5,7 @@ import argparse
 import subprocess
 import os
 import sys
+import shlex
 
 from contextlib import contextmanager
 
@@ -18,6 +19,9 @@ FIRMWARE_REPO="https://github.com/dwyl/smart-home-firmware.git"
 # Declare the start message here so we don't clog up the rest of the code
 START_MESSAGE="""
 Smart home is now setup for development.
+
+To setup your development evironment:
+    source .env
 
 To run the hub server:
 
@@ -53,6 +57,11 @@ def out(line):
 def run(*args):
   return subprocess.run(args, capture_output=not VERBOSE)
 
+def write_env(key):
+  with open(".env", "w") as f:
+    contents = "AUTH_API_KEY=" + key + "\n"
+    f.write(contents)
+
 # Dowload required files from github.
 def download():
   out("Downloading Hub Server...")
@@ -70,15 +79,20 @@ def get_api_key():
   print("https://git.io/JJ6sS")
   print("")
   print("Please enter your API key once your done to continue setup")
-  os.environ["AUTH_API_KEY"] = input(">")
+  key = input(">")
+  os.environ["AUTH_API_KEY"] = key
+
+  return key
 
 # Check if we have an auth API key set before continuing
 def check_for_api_key():
-  if os.environ.get("AUTH_API_KEY", None):
-    # API key set
+  key = os.environ.get("AUTH_API_KEY", None)
+  if key:
     pass
   else:
-    get_api_key()
+    key = get_api_key()
+
+  write_env(key)
 
 # Get and display a local API development token for the user
 def gen_token():
@@ -116,6 +130,7 @@ def clean():
   out("Cleaning up...")
   run("rm", "-rf", "./smart-home-auth-server")
   run("rm", "-rf", "./smart-home-firmware")
+  run("rm", ".env")
   out("OK\n")
 
 # Declare our command parsers and run the intended function

--- a/manage.py
+++ b/manage.py
@@ -170,6 +170,13 @@ def install_deps(brew, missing):
   out("Installing PostgreSQL...\n")
   run(shlex.split("brew install postgres"))
 
+def install_nerves_dependencies():
+  if input("Do you want to install build dependencies for nerves? (fwup squashfs coreutils xz pkg-config)? (y/N)")[0] == "y":
+    run(shlex.split("brew install fwup squashfs coreutils xz pkg-config"))
+  else:
+    out("NERVES WILL FAIL TO BUILD WITHOUT DEPS INSTALLED \n")
+    out("https://hexdocs.pm/nerves/installation.html#content\n")
+  
 def pre_install():
   deps = check_deps()
   brew = deps["brew"]
@@ -193,6 +200,7 @@ def setup():
   # Setup firmware
   with cd("./smart-home-firmware"):
     out("Installing firmware deps...")
+    install_nerves_dependencies()
     run("mix", "deps.get")
     out("OK\n")
 

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,98 @@
+# Management script for dwyl smart home
+
+import argparse
+import subprocess
+import os
+
+from contextlib import contextmanager
+
+# Global verbose flag to toggle on/off verbose output
+VERBOSE=False
+
+# Declare global constants
+HUB_SERVER_REPO="https://github.com/dwyl/smart-home-auth-server.git"
+FIRMWARE_REPO="https://github.com/dwyl/smart-home-firmware.git"
+
+# Emulate a shells `cd`
+# https://stackoverflow.com/questions/431684/
+@contextmanager
+def cd(newdir):
+    prevdir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)
+
+# Helper function to allow for same line I/O without repeating ourselves
+def out(line):
+  print(line, end="", flush=True)
+
+def run(*args):
+  return subprocess.run(args, capture_output=not VERBOSE)
+
+# Dowload required files from github.
+def download():
+  out("Downloading Hub Server...")
+  process = run("git", "clone", HUB_SERVER_REPO)
+  out("OK\n")
+
+  out("Downloading firmware...")
+  process = run("git", "clone", FIRMWARE_REPO)
+  out("OK\n")
+
+def get_api_key():
+  print("AUTH_API_KEY not set!\n")
+  print("No Auth API key set, found out how at:")
+  print("https://git.io/JJ6sS")
+  print("")
+  print("Please enter your API key once your done to continue setup")
+  os.environ["AUTH_API_KEY"] = input(">")
+
+def check_for_api_key():
+  if os.environ.get("AUTH_API_KEY", None):
+    # API key set
+    pass
+  else:
+    get_api_key()
+
+def setup():
+  print(os.getcwd())
+  # Setup firmware
+  with cd("./smart-home-firmware"):
+    out("Installing firmware deps...")
+    run("mix", "deps.get")
+    out("OK\n")
+
+  with cd("./smart-home-auth-server"):
+    out("Installing hub server deps...")
+    run("mix", "setup")
+    out("OK\n")
+
+
+# Run necessary install functions
+def install():
+  download()
+  check_for_api_key()
+  setup()
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Manage Dwyl smart home install")
+  parser.add_argument("-v", "--verbose", help="Enable verbose output", action="store_true")
+  subparsers = parser.add_subparsers(help="Commands")
+
+  install_parser = subparsers.add_parser("install")
+  install_parser.set_defaults(func=install)
+  args = parser.parse_args()
+
+  global VERBOSE
+  VERBOSE = args.verbose
+
+  print(args.verbose)
+  if args.func:
+    args.func()
+
+
+if __name__ == "__main__":
+  main()

--- a/manage.py
+++ b/manage.py
@@ -10,7 +10,7 @@ import shlex
 from contextlib import contextmanager
 
 # Global verbose flag to toggle on/off verbose output
-VERBOSE=False
+VERBOSE=True
 
 # Declare global constants
 HUB_SERVER_REPO="https://github.com/dwyl/smart-home-auth-server.git"
@@ -68,7 +68,7 @@ def write_env(key):
       lines = [x for x in keys]
   except FileNotFoundError:
     pass
-  
+
   lines.append("AUTH_API_KEY=" + key + "\n")
   
   with open(".env", "w") as f:
@@ -148,7 +148,6 @@ def clean():
 # Declare our command parsers and run the intended function
 def main():
   parser = argparse.ArgumentParser(description="Manage Dwyl smart home install")
-  parser.add_argument("-v", "--verbose", help="Enable verbose output", action="store_true")
   subparsers = parser.add_subparsers(help="Commands")
   subparsers.default = "help"
 
@@ -167,8 +166,6 @@ def main():
 
   args = parser.parse_args()
 
-  global VERBOSE
-  VERBOSE = args.verbose
 
   if args.func:
     args.func()


### PR DESCRIPTION
Install scripts to allow for a "One Click" setup of smart home.

Can be used by running: 

```
bash <(curl -sL https://git.io/JUIen) # POSIX-compatible shell (e.g. bash/zsh/most shells)
bash (curl -sL https://git.io/JUIen | psub) # Fish shell
```

This will download and install the smart-home-security-system repositories and do any required configuration changes.
Will fix #11 